### PR TITLE
Animation trigger when "active" prop is updated

### DIFF
--- a/Hamburger.js
+++ b/Hamburger.js
@@ -200,6 +200,11 @@ export default class Hamburger extends Component {
 
 
     }
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.active !== this.state.active) {
+            this._animate();
+        }
+    }
     componentDidMount() {
         setTimeout(()=> {
             this.setState({


### PR DESCRIPTION
Tried to update the 'active' prop without pressing the hamburger. The animate function does not trigger. 
This PR fix this.

I think it resolve issue https://github.com/GeekyAnts/react-native-hamburger/issues/1 too